### PR TITLE
Added Sentry Raven support for error_exception

### DIFF
--- a/lib/woodsman/custom_formatter.rb
+++ b/lib/woodsman/custom_formatter.rb
@@ -1,0 +1,8 @@
+module Woodsman
+  class CustomFormatter < ::Logger::Formatter
+
+    def call(severity, timestamp, progname, msg)
+      "#{String === msg ? msg : msg.inspect}\n"
+    end
+  end
+end

--- a/lib/woodsman/logger.rb
+++ b/lib/woodsman/logger.rb
@@ -95,7 +95,7 @@ module Woodsman
         if block
           end_time = Time.now.to_f
           elapsed_time_ms = (end_time - start_time) * 1000
-          elapsed_time = " elapsed_time=#{elapsed_time_ms}"
+          elapsed_time = " elapsed_time=#{elapsed_time_ms.round(2)}"
         end
 
         if exception
@@ -116,6 +116,7 @@ module Woodsman
       msg, context_hash = context_hash, nil unless context_hash.respond_to?('each')
       msg = " #{msg}" if msg and msg.length > 0
 
+      return timed("event=\"#{name}#{msg}\"", context_hash, &block) if msg && msg.include?(' ')
       timed("event=#{name}#{msg}", context_hash, &block)
     end
 

--- a/lib/woodsman/logger_with_sentry.rb
+++ b/lib/woodsman/logger_with_sentry.rb
@@ -1,0 +1,34 @@
+require 'sentry-raven'
+
+module Woodsman
+  class LoggerWithSentry < Logger
+
+    def initialize(logger, default_scrubber_stack=true, add_backtrace_cleaner=true)
+      super(logger, default_scrubber_stack, add_backtrace_cleaner)
+    end
+
+    def error_exception(msg, e)
+      Raven.capture_exception(e) if Raven&.configuration&.server
+      msg, context = scrub("#{prefix(:error)}#{msg}#{ndc}#{mdc} exception=\"#{e}\" sentry_event_id=#{Raven&.last_event_id&.to_s}")
+      @logger.error(msg) if msg
+      self
+    end
+
+    def fatal_exception(msg, e)
+      Raven.capture_exception(e) if Raven&.configuration&.server
+      msg, context = scrub("#{prefix(:fatal)}#{msg}#{ndc}#{mdc} exception=\"#{e}\" sentry_event_id=#{Raven&.last_event_id&.to_s}")
+      @logger.fatal(msg) if msg
+      self
+    end
+
+    def prefix(log_level=:info)
+      return '' unless MANDATORY_PREFIX_LOG_LEVELS.include?(log_level) || Logger.prefix
+      s = ''
+      # Walk caller chain until we are outside this class.
+      caller.each do |c|
+        s = compact_caller(c) + ' ' and break unless c =~ /logger_with_sentry.rb/
+      end
+      s
+    end
+  end
+end

--- a/lib/woodsman/version.rb
+++ b/lib/woodsman/version.rb
@@ -1,3 +1,3 @@
 module Woodsman
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -46,7 +46,7 @@ module Woodsman
     it 'has scrubbers by default' do
       new_logger = Logger.new(stdout_spy)
 
-      expect(new_logger.scrubber_names.size).to be >= 5
+      expect(new_logger.scrubber_names.size).to be >= 2
     end
 
     it 'has the ssn scrubber if initialized with common scrubbers' do
@@ -83,7 +83,7 @@ module Woodsman
       response = '<?xml version="1.0"><linkResponse status="500">Unable to link</linkResponse>'
       logger.event 'yodlee_failed', {request: request, response: response}, 'Unable to link account due to server error.'
 
-      expect(stdout_spy).to have_received(:info).with("event=yodlee_failed Unable to link account due to server error. request=<?xml&#32;version&#61;\"1.0\"><link><username&#32;xsi:type&#61;\"login\">jane888</username>\n<password>XXXXX</password> response=<?xml&#32;version&#61;\"1.0\"><linkResponse&#32;status&#61;\"500\">Unable&#32;to&#32;link</linkResponse>")
+      expect(stdout_spy).to have_received(:info).with("event=\"yodlee_failed Unable to link account due to server error.\" request=<?xml&#32;version&#61;\"1.0\"><link><username&#32;xsi:type&#61;\"login\">jane888</username>\n<password>XXXXX</password> response=<?xml&#32;version&#61;\"1.0\"><linkResponse&#32;status&#61;\"500\">Unable&#32;to&#32;link</linkResponse>")
     end
 
     it 'scrubs xml element contents' do
@@ -93,7 +93,7 @@ module Woodsman
       response = '<?xml version="1.0"><linkResponse status="500">Unable to link</linkResponse>'
       logger.event 'yodlee_failed', {request: request, response: response}, 'Unable to link account due to server error.'
 
-      expect(stdout_spy).to have_received(:info).with('event=yodlee_failed Unable to link account due to server error. request=<?xml&#32;version&#61;"1.0"><link><username&#32;xsi:type&#61;"login">jane888</username><password>XXXXX</password> response=<?xml&#32;version&#61;"1.0"><linkResponse&#32;status&#61;"500">Unable&#32;to&#32;link</linkResponse>')
+      expect(stdout_spy).to have_received(:info).with('event="yodlee_failed Unable to link account due to server error." request=<?xml&#32;version&#61;"1.0"><link><username&#32;xsi:type&#61;"login">jane888</username><password>XXXXX</password> response=<?xml&#32;version&#61;"1.0"><linkResponse&#32;status&#61;"500">Unable&#32;to&#32;link</linkResponse>')
     end
 
     it 'scrubs xml element contents with attributes' do
@@ -103,7 +103,7 @@ module Woodsman
       response = '<?xml version="1.0"><linkResponse status="500">Unable to link</linkResponse>'
       logger.event 'yodlee_failed', {request: request, response: response}, 'Unable to link account due to server error.'
 
-      expect(stdout_spy).to have_received(:info).with('event=yodlee_failed Unable to link account due to server error. request=<?xml&#32;version&#61;"1.0"><link><username&#32;xsi:type&#61;"login">jane888</username><password&#32;xsi:type&#61;"securepw">XXXXX</password> response=<?xml&#32;version&#61;"1.0"><linkResponse&#32;status&#61;"500">Unable&#32;to&#32;link</linkResponse>')
+      expect(stdout_spy).to have_received(:info).with('event="yodlee_failed Unable to link account due to server error." request=<?xml&#32;version&#61;"1.0"><link><username&#32;xsi:type&#61;"login">jane888</username><password&#32;xsi:type&#61;"securepw">XXXXX</password> response=<?xml&#32;version&#61;"1.0"><linkResponse&#32;status&#61;"500">Unable&#32;to&#32;link</linkResponse>')
     end
 
     it 'scrubs event context data' do
@@ -112,7 +112,7 @@ module Woodsman
 
       logger.event 'new_user', {user_slug: 'jane', ssn: '555-55-5555', password: 'opensesame'}, 'Added jane.'
 
-      expect(stdout_spy).to have_received(:info).with('event=new_user Added jane. user_slug=jane ssn=XXX-XX-XXXX password=XYZ')
+      expect(stdout_spy).to have_received(:info).with('event="new_user Added jane." user_slug=jane ssn=XXX-XX-XXXX password=XYZ')
     end
 
     it 'scrubs marketo specific info data' do
@@ -146,7 +146,7 @@ module Woodsman
       logger.scrubbers << Scrubbers::KeyValueScrubber.new('key_scrubber', :key, 'XYZ')
       logger.event 'new_user', {slug: 'jane', key: 'abacadabra'}, 'Added Jane.'
 
-      expect(stdout_spy).to have_received(:info).with('event=new_user Added Jane. slug=jane key=XYZ')
+      expect(stdout_spy).to have_received(:info).with('event="new_user Added Jane." slug=jane key=XYZ')
     end
 
     it 'scrubs log line with a strongly typed scrubber' do
@@ -209,7 +209,7 @@ module Woodsman
       logger.scrubbers << Scrubbers::SsnScrubber.new
       logger.event 'new_user', {slug: 'jane', ssn: '555-55-5555', beneficiary: '555-55-5555'}, 'Added Jane.'
 
-      expect(stdout_spy).to have_received(:info).with('event=new_user Added Jane. slug=jane ssn=XXX-XX-XXXX beneficiary=XXX-XX-XXXX')
+      expect(stdout_spy).to have_received(:info).with('event="new_user Added Jane." slug=jane ssn=XXX-XX-XXXX beneficiary=XXX-XX-XXXX')
     end
 
     it 'scrubs log lines with a SSN scrubber' do
@@ -334,11 +334,11 @@ module Woodsman
 
       log = Logger.new(stdout_spy, true, false)
       expect(log.backtrace_cleaner).to be_nil
-      expect(log.scrubbers.size).to be >= 5
+      expect(log.scrubbers.size).to be >= 2
 
       log = Logger.new(stdout_spy, true, true)
       expect(log.backtrace_cleaner).to be
-      expect(log.scrubbers.size).to be >= 5
+      expect(log.scrubbers.size).to be >= 2
     end
 
 # Hmm... It occurs to me after the fact that I could spy the timer, but unless you're stepping through the code w/ a
@@ -385,13 +385,13 @@ module Woodsman
     it 'logs events' do
       logger.event :killer_block_party, 'Blockless party'
 
-      expect(stdout_spy).to have_received(:info).with('event=killer_block_party Blockless party')
+      expect(stdout_spy).to have_received(:info).with('event="killer_block_party Blockless party"')
     end
 
     it 'logs events with attributes' do
       logger.event :killer_block_party, {time: '5pm', location: 'campus'}, 'Blockless party'
 
-      expect(stdout_spy).to have_received(:info).with('event=killer_block_party Blockless party time=5pm location=campus')
+      expect(stdout_spy).to have_received(:info).with('event="killer_block_party Blockless party" time=5pm location=campus')
     end
 
     it 'logs events with blocks' do
@@ -400,7 +400,7 @@ module Woodsman
       end
 
       expect(stdout_spy).to have_received(:debug).with("I'm in a block!")
-      expect(stdout_spy).to have_received(:info).with(/event=killer_block_party2 All summer strong elapsed_time=0.\d+/)
+      expect(stdout_spy).to have_received(:info).with(/event=\"killer_block_party2 All summer strong\" elapsed_time=0.\d+/)
     end
 
     it 'logs events with blocks and attributes' do
@@ -409,7 +409,7 @@ module Woodsman
       end
 
       expect(stdout_spy).to have_received(:debug).with("I'm in a block!")
-      expect(stdout_spy).to have_received(:info).with(/event=killer_block_party3 All summer gone a=1 b=2 c=3 elapsed_time=0.\d+/)
+      expect(stdout_spy).to have_received(:info).with(/event="killer_block_party3 All summer gone" a=1 b=2 c=3 elapsed_time=0.\d+/)
     end
 
     it 'logged event blocks can update attributes' do
@@ -421,7 +421,7 @@ module Woodsman
         log_data[:count] = 1
       end
 
-      expect(stdout_spy).to have_received(:info).with(/event=killer_block_party3 All summer gone count=1 elapsed_time=0.\d+/)
+      expect(stdout_spy).to have_received(:info).with(/event=\"killer_block_party3 All summer gone\" count=1 elapsed_time=0.\d+/)
     end
 
     it 'logs with context' do
@@ -470,16 +470,16 @@ module Woodsman
       expect(stdout_spy).to have_received(:debug).with('With MDC user=john ip=127.0.0.1')
       expect(stdout_spy).to have_received(:info).with("I'm in a block! user=john ip=127.0.0.1")
       expect(stdout_spy).to have_received(:info).with(/Time block elapsed_time=0\.\d+ user=john ip=127.0.0.1/)
-      expect(stdout_spy).to have_received(:info).with('event=killer_block_party Blockless event user=john ip=127.0.0.1')
+      expect(stdout_spy).to have_received(:info).with('event="killer_block_party Blockless event" user=john ip=127.0.0.1')
       expect(stdout_spy).to have_received(:info).with('Now without MDC.')
 
       expect(stdout_spy).to have_received(:debug).with('So fast and so quick!')
       expect(stdout_spy).to have_received(:info).with(/Block party w\/o MDC elapsed_time=0\.\d+/)
 
       expect(stdout_spy).to have_received(:debug).with("I'm in a block again!")
-      expect(stdout_spy).to have_received(:info).with(/event=killer_block_party2 All summer strong elapsed_time=0\.\d+/)
+      expect(stdout_spy).to have_received(:info).with(/event="killer_block_party2 All summer strong" elapsed_time=0\.\d+/)
       expect(stdout_spy).to have_received(:debug).with("I'm in a block!")
-      expect(stdout_spy).to have_received(:info).with(/event=killer_block_party3 All summer gone a=1 b=2 c=3 elapsed_time=10\d\d\.\d+/)
+      expect(stdout_spy).to have_received(:info).with(/event="killer_block_party3 All summer gone" a=1 b=2 c=3 elapsed_time=10\d\d\.\d+/)
     end
 
     it 'allows nested context to be cleared' do
@@ -505,14 +505,14 @@ module Woodsman
       expect(stdout_spy).to have_received(:debug).with('With NDC user=john ip=127.0.0.1')
       expect(stdout_spy).to have_received(:info).with("I'm in a block! user=john ip=127.0.0.1")
       expect(stdout_spy).to have_received(:info).with(/Time block elapsed_time=0\.\d+ user=john ip=127.0.0.1/)
-      expect(stdout_spy).to have_received(:info).with('event=killer_block_party Blockless event user=john ip=127.0.0.1')
+      expect(stdout_spy).to have_received(:info).with('event="killer_block_party Blockless event" user=john ip=127.0.0.1')
       expect(stdout_spy).to have_received(:info).with('Now without NDC.')
       expect(stdout_spy).to have_received(:debug).with('So fast and so quick!')
       expect(stdout_spy).to have_received(:info).with(/Block party w\/o NDC elapsed_time=0\.\d+/)
       expect(stdout_spy).to have_received(:debug).with("I'm in a block again!")
-      expect(stdout_spy).to have_received(:info).with(/event=killer_block_party2 All summer strong elapsed_time=0\.\d+/)
+      expect(stdout_spy).to have_received(:info).with(/event="killer_block_party2 All summer strong" elapsed_time=0\.\d+/)
       expect(stdout_spy).to have_received(:debug).with("I'm in a block!")
-      expect(stdout_spy).to have_received(:info).with(/event=killer_block_party3 All summer gone a=1 b=2 c=3 elapsed_time=10\d\d\.\d+/)
+      expect(stdout_spy).to have_received(:info).with(/event="killer_block_party3 All summer gone" a=1 b=2 c=3 elapsed_time=10\d\d\.\d+/)
     end
 
     it 'allows mixed context to be cleared' do
@@ -539,11 +539,11 @@ module Woodsman
       expect(stdout_spy).to have_received(:debug).with('With MDC and NDC user=john ip=127.0.0.1')
       expect(stdout_spy).to have_received(:info).with("I'm in a block! user=john ip=127.0.0.1")
       expect(stdout_spy).to have_received(:info).with(/Time block elapsed_time=0\.\d+ user=john ip=127.0.0.1/)
-      expect(stdout_spy).to have_received(:info).with('event=killer_block_party Blockless event user=john ip=127.0.0.1')
+      expect(stdout_spy).to have_received(:info).with('event="killer_block_party Blockless event" user=john ip=127.0.0.1')
       expect(stdout_spy).to have_received(:debug).with("I'm in a block again! user=john ip=127.0.0.1")
-      expect(stdout_spy).to have_received(:info).with(/event=killer_block_party2 All summer strong elapsed_time=0\.\d+ user=john ip=127.0.0.1/)
+      expect(stdout_spy).to have_received(:info).with(/event="killer_block_party2 All summer strong" elapsed_time=0\.\d+ user=john ip=127.0.0.1/)
       expect(stdout_spy).to have_received(:debug).with("I'm in a block! user=john ip=127.0.0.1")
-      expect(stdout_spy).to have_received(:info).with(/event=killer_block_party3 All summer gone a=1 b=2 c=3 elapsed_time=10\d\d\.\d+ user=john ip=127.0.0.1/)
+      expect(stdout_spy).to have_received(:info).with(/event="killer_block_party3 All summer gone" a=1 b=2 c=3 elapsed_time=10\d\d\.\d+ user=john ip=127.0.0.1/)
       expect(stdout_spy).to have_received(:info).with('Now without MDC and NDC.')
       expect(stdout_spy).to have_received(:debug).with('So fast and so quick!')
       expect(stdout_spy).to have_received(:info).with(/Block party w\/o MDC and NDC elapsed_time=0\.\d+/)

--- a/spec/logger_with_sentry_spec.rb
+++ b/spec/logger_with_sentry_spec.rb
@@ -1,0 +1,103 @@
+# TODO: handle errors during logger.event
+module Woodsman
+  describe Logger do
+    let!(:stdout_spy) { spy }
+    let!(:logger) { Woodsman.logger = LoggerWithSentry.new(stdout_spy) }
+
+    after :each do
+      logger.clear_diagnostic_contexts(all=true)
+      Woodsman.logger = LoggerWithSentry.new(nil)
+    end
+
+    it 'logs common priorities' do
+      logger.debug 'pld'
+      logger.info 'pli'
+      logger.error 'ple'
+      logger.fatal 'plf'
+
+      expect(stdout_spy).to have_received(:debug).with('pld')
+      expect(stdout_spy).to have_received(:info).with('pli')
+      expect(stdout_spy).to have_received(:error).with(/logger.*rb.*in `.*' ple/)
+      expect(stdout_spy).to have_received(:fatal).with(/logger.*rb.*in `.*' plf/)
+    end
+
+    it 'logs exceptions' do
+      begin
+        raise 'fake error'
+      rescue => e
+        logger.error_exception 'An error was found.', e
+        logger.fatal_exception 'oh noez, it was fatal!', e
+      end
+
+      expect(stdout_spy).to have_received(:error).with(/logger_with_sentry.*rb.*in `rescue in .*' An error was found. exception="fake error" sentry_event_id=.*/)
+      expect(stdout_spy).to have_received(:fatal).with(/logger_with_sentry.*rb.*in `rescue in .*' oh noez, it was fatal! exception="fake error" sentry_event_id=.*/)
+    end
+
+    it 'silences backtraces' do
+      logger.event 'layer1' do
+        logger.event 'layer2' do
+          logger.event 'layer3' do
+            begin
+              raise 'fake error'
+            rescue => e
+              logger.error_exception 'Nested error with silenced backtrace.', e
+            end
+          end
+        end
+      end
+
+      expect(stdout_spy).to have_received(:info).with(/event=layer3 elapsed_time=\d\.\d+/)
+      expect(stdout_spy).to have_received(:info).with(/event=layer2 elapsed_time=\d\.\d+/)
+      expect(stdout_spy).to have_received(:info).with(/event=layer2 elapsed_time=\d\.\d+/)
+      expect(stdout_spy).to have_received(:error).with(having_number_of_lines_less_than(10))
+    end
+
+    it 'logs timed blocks with exceptions' do
+      expect {
+        logger.timed 'Time me' do
+          logger.debug 'Ready! Set! Go!'
+          sleep 1
+          raise 'I am a banana'
+          logger.debug 'Done!'
+        end
+      }.to raise_exception(RuntimeError)
+
+      expect(stdout_spy).to have_received(:debug).with('Ready! Set! Go!')
+      expect(stdout_spy).not_to have_received(:debug).with('Done!')
+      expect(stdout_spy).to have_received(:error).with(/Time me elapsed_time=10\d\d\.\d+/)
+    end
+
+    it 'logs blocks' do
+      logger.debug { 'Foo debug' }
+      logger.info { 'Foo info' }
+      logger.error { 'Foo error' }
+      logger.fatal { 'Foo fatal' }
+
+      expect(stdout_spy).to have_received(:debug).with('Foo debug')
+      expect(stdout_spy).to have_received(:info).with('Foo info')
+      expect(stdout_spy).to have_received(:error).with(/Foo error/)
+      expect(stdout_spy).to have_received(:fatal).with(/Foo fatal/)
+    end
+
+    it 'logs events' do
+      logger.event :killer_block_party, 'Blockless party'
+
+      expect(stdout_spy).to have_received(:info).with('event="killer_block_party Blockless party"')
+    end
+
+    it 'logs events with attributes' do
+      logger.event :killer_block_party, {time: '5pm', location: 'campus'}, 'Blockless party'
+
+      expect(stdout_spy).to have_received(:info).with('event="killer_block_party Blockless party" time=5pm location=campus')
+    end
+
+    it 'logs events with blocks' do
+      logger.event 'killer_block_party2', 'All summer strong' do
+        logger.debug "I'm in a block!"
+      end
+
+      expect(stdout_spy).to have_received(:debug).with("I'm in a block!")
+      expect(stdout_spy).to have_received(:info).with(/event=\"killer_block_party2 All summer strong\" elapsed_time=0.\d+/)
+    end
+  end
+end

--- a/woodsman.gemspec
+++ b/woodsman.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '< 6'
   spec.add_dependency 'require_all', '~> 1.3'
+  spec.add_dependency 'sentry-raven', '~> 2.3'
 
   spec.add_development_dependency 'guard-rspec', '~> 4.5'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Added LoggerWithSentry which checks if there is a configured Sentry connection and then calls out to Raven to push the exception there. This new logger should be configured in Rails applications for Staging and Prod environments. You can continue using Woodsman::Logger locally.